### PR TITLE
Add the Recall Knowledge roll to the chat message

### DIFF
--- a/src/actions/recall-knowledge.js
+++ b/src/actions/recall-knowledge.js
@@ -61,6 +61,7 @@ export async function rollRecallKnowledges(actor) {
         flavor,
         speaker: ChatMessage.getSpeaker({ actor }),
         rollMode: CONST.DICE_ROLL_MODES.BLIND,
+        rolls: [roll],
         type: CONST.CHAT_MESSAGE_TYPES.ROLL,
     })
 }

--- a/templates/chat/recall-knowledge.hbs
+++ b/templates/chat/recall-knowledge.hbs
@@ -3,7 +3,6 @@
     <h4 class="action">
         <span class="pf2-icon larger">A</span>
         <strong>{{localize 'PF2E.RecallKnowledge.Label'}}</strong>
-        <p class="compact-text">({{localize 'PF2E.Roll.Roll'}}: <span class="success {{dieSuccess}}">{{dieResult}}</span>)</p>
     </h4>
 
     {{#if target}}


### PR DESCRIPTION
- Makes the roll show up with Dice So Nice
- Fixes an incompatibility with Cautious Gamemaster's Pack that makes the roll visible to everyone